### PR TITLE
README.md: Added additional C# implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Other implementations of Ryu:
 | Go               | Caleb Spare        | https://github.com/cespare/ryu                |
 | C++              | Cqwrteur           | https://github.com/expnkx/fast_io             |
 | C#               | Dogwei             | https://github.com/Dogwei/RyuCsharp           |
+| C#               | Shad Storhaug      | https://github.com/NightOwl888/J2N            |
 | D                | Ilya Yaroshenko    | [https://github.com/libmir/mir-algorithm][5]  |
 | Scala            | Denys Shabalin     | [https://github.com/scala-native/scala-native][4] |
 | Erlang/BEAM      | Thomas Depierre    | https://github.com/erlang/otp/tree/master/erts/emulator/ryu |


### PR DESCRIPTION
We did a port of the Java Ryu implementation to C# in J2N.

- https://github.com/NightOwl888/J2N/blob/ceaa3d17f3866a5ec4865f9be600b76c5303764c/src/J2N/Numerics/RyuDouble.cs
- https://github.com/NightOwl888/J2N/blob/ceaa3d17f3866a5ec4865f9be600b76c5303764c/src/J2N/Numerics/RyuSingle.cs

Ryu formatting is exposed through the "J" (default) format of the `ToString()` method overloads on the following public classes.

- https://github.com/NightOwl888/J2N/blob/ceaa3d17f3866a5ec4865f9be600b76c5303764c/src/J2N/Numerics/Double.cs#L2195-L3020
- https://github.com/NightOwl888/J2N/blob/ceaa3d17f3866a5ec4865f9be600b76c5303764c/src/J2N/Numerics/Single.cs#L2189-L3014

The implementation uses the Ryu algorithm to provide a round-trippable format/parse that consistently works from .NET Framework 4.0 to .NET 6+. .NET has floating point rounding bugs which weren't patched until .NET Core 3.0, but J2N provides consistent round-trip behavior across all target frameworks with the help of `RyuDouble` and `RyuSingle`.